### PR TITLE
Fix typo in mkdir script

### DIFF
--- a/anonymize.sh
+++ b/anonymize.sh
@@ -45,7 +45,7 @@ curdir=$(pwd)
 an_filename="_anonymized_$1"
 zipdir="/tmp/libreoffice"
 
-mkdir $zipdir 2&> /dev/null
+mkdir $zipdir &> /dev/null
 rm -rf ${zipdir:?}/*
 
 function check_i {


### PR DESCRIPTION
This fixes a bug where a directory named '2' is created after every time the script is run.