### PR TITLE
Save file in correct location

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,6 @@ from any directory and it should produce a copy with `_anon_` prepended to the f
 
 ## TODO
 
-- [ ] make it work from other directories (done for python!)
 - [ ] opt out removing initials, now it's just done at the end
+- [ ] remove also document creator, for full anonymization (now only creators)
+- [ ] make it work also for doucments without comments!

--- a/anonymize.py
+++ b/anonymize.py
@@ -129,7 +129,7 @@ class File():
     def rezip(self, output_prefix, output_dir):
         # Recreate a version of the file with the new content in it
 
-        output_file = os.path.join(output_dir, output_prefix + self.name)
+        output_file = os.path.join(output_dir, output_prefix + os.path.basename(self.name))
         shutil.make_archive(output_file, "zip", self.tmp_dir)
 
         output_file_zip = output_file + ".zip"


### PR DESCRIPTION
Previous behavior would save to a nested structure in the current
directory if run on a file outside the current directory.