### PR TITLE
feature: Keep dates as default

### DIFF
--- a/anonymize.py
+++ b/anonymize.py
@@ -369,7 +369,7 @@ if __name__ == '__main__':
     parser.add_argument("--remove-dates", action="store_true",
                         help="Remove also the dates form tracked edits")
     parser.add_argument("--keep-initials", action="store_true",
-                        help="Keep the author's initials")
+                        help="Keep the comment authors' initials")
     args = parser.parse_args()
 
     # Cleanup the main tmp_dir

--- a/anonymize.py
+++ b/anonymize.py
@@ -366,8 +366,8 @@ if __name__ == '__main__':
                         help="Prefix for output files.")
     parser.add_argument("--output-dir", type=str, default = Path.cwd(),
                         help="Directory for output files")
-    parser.add_argument("--keep-dates", action="store_true",
-                        help="Keep the comment dates")
+    parser.add_argument("--remove-dates", action="store_true",
+                        help="Removes also the comment dates")
     parser.add_argument("--keep-initials", action="store_true",
                         help="Keep the commenter initials")
     args = parser.parse_args()
@@ -385,7 +385,7 @@ if __name__ == '__main__':
     if not args.keep_initials:
         delete_initials(files)
 
-    if not args.keep_dates:
+    if args.remove_dates:
         delete_dates(files)
 
     anonymized_files = rezip(files, args.output_prefix, args.output_dir)

--- a/anonymize.py
+++ b/anonymize.py
@@ -367,7 +367,7 @@ if __name__ == '__main__':
     parser.add_argument("--output-dir", type=str, default = Path.cwd(),
                         help="Directory for output files")
     parser.add_argument("--remove-dates", action="store_true",
-                        help="Remove also the dates form tracked edits")
+                        help="Remove dates from tracked edits")
     parser.add_argument("--keep-initials", action="store_true",
                         help="Keep the comment authors' initials")
     args = parser.parse_args()

--- a/anonymize.py
+++ b/anonymize.py
@@ -367,9 +367,9 @@ if __name__ == '__main__':
     parser.add_argument("--output-dir", type=str, default = Path.cwd(),
                         help="Directory for output files")
     parser.add_argument("--remove-dates", action="store_true",
-                        help="Removes also the comment dates")
+                        help="Remove also the dates form tracked edits")
     parser.add_argument("--keep-initials", action="store_true",
-                        help="Keep the commenter initials")
+                        help="Keep the author's initials")
     args = parser.parse_args()
 
     # Cleanup the main tmp_dir


### PR DESCRIPTION
Keeping the dates seems a more sensible default option. Changed the argument name and help to better fit the scope of the edits.